### PR TITLE
Use canonical article location

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@
 ### Blogs
 
 - [CodingJunkie](http://codingjunkie.net/) - Random Thoughts on Coding by Bill Bejeck.
-- [Understanding Kafka with Factorio](https://hackernoon.com/understanding-kafka-with-factorio-74e8fc9bf181)
+- [Understanding Kafka with Factorio]([https://ruurtjan.com/articles/understanding-kafka-with-factorio)
 
 ### Books
 


### PR DESCRIPTION
I've moved this article from Hackernoon to my personal site.

This PR changes the location in the readme.