### PR TITLE
Add Kafka related Ballerina libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@
 - [dharmeshkakadia/awesome-kafka](https://github.com/dharmeshkakadia/awesome-kafka)
 - [infoslack/awesome-kafka](https://github.com/infoslack/awesome-kafka)
 - [awesome-kafka-playground](https://github.com/anascotti/awesome-kafka-playground)
+- [ballerina-avro-kafka-serializer](https://github.com/ballerina-platform/module-ballerinax-confluent.cavroserdes) - Ballerina Confluent Avro Serializer/Deserializer
 
 ### Kafkaesque
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 - [apicurio-registry](https://github.com/Apicurio/apicurio-registry) - Apicurio API/schema registry (includes UI).
 - [schema-registry](https://github.com/confluentinc/schema-registry) - Confluent Schema registry for Kafka.
 - [ksql-jdbc-driver](https://github.com/mmolimar/ksql-jdbc-driver)
+- [ballerina-schema-registry](https://github.com/ballerina-platform/module-ballerinax-confluent.cregistry) - Ballerina Confluent Schema Registry
 
 ### Other Awesome Kafka
 


### PR DESCRIPTION
The following libraries in Ballerina has been added to the listing.

- Ballerina Schema Registry - This library integrates with Confluent's Avro Schema Registry and provide users to efficiently manage schemas within Kafka applications.

- Ballerina Avro Kafka Serializer - This library integrates with the Confluent Schema Registry for Avro serialization and deserialization within Kafka applications.