### PR TITLE
Adding Bufstream to Kafkaesque

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 - [faust](https://github.com/robinhood/faust) - Python Stream Processing.
 - [redpanda](https://vectorized.io/)
 - [Meteor](https://github.com/obsidiandynamics/meteor) - Lightweight, broker-less alternative to Kafka for message streaming.
+- [Bufstream](https://buf.build/product/bufstream) - Store directly to Apache Iceberg™ tables and guarantee data quality with Bufstream, a drop-in replacement for Apache Kafka®.
 
 ## Resources
 


### PR DESCRIPTION
> Search previous suggestions before making a new one, as yours may be a duplicate.

There are no prior PRs for "Buf" or "Bufstream."

> Suggested packages should be tested and documented.

Bufstream is tested and [documented](https://buf.build/docs/bufstream/).

> Make an individual pull request for each suggestion.

This is an individual suggestion.

> Use the following format: [package](link) - Description.

Done. 

> New categories, or improvements to the existing categorization are welcome.

No improvements suggested.

> Keep descriptions short and simple, but descriptive.

Description is simple and shorter than other descriptions.

> End all descriptions with a full stop/period.

Done. It also includes appropriate citations of trademarks.

> Check your spelling and grammar.

Done.

> Make sure your text editor is set to remove trailing whitespace.

Done.

> The pull request should include a link to the package and why it should be included.

Link: (https://buf.build/product/bufstream)
Why it should be included: 

Bufstream is the Kafka-compatible message queue built for the data lakehouse era. It's a drop-in replacement for Apache Kafka®, but instead of requiring expensive machines with large attached disks, Bufstream builds on top of off-the-shelf technologies such as S3 and Postgres to provide a Kafka implementation that is built for 2025.